### PR TITLE
Allow Envar.get to set default value

### DIFF
--- a/lib/envar.ex
+++ b/lib/envar.ex
@@ -17,20 +17,28 @@ defmodule Envar do
   When the environment variable is not defined,
   this will be logged for debugging purposes.
 
+  An optional default parameter may be provided to return
+  value if environment variable is not set.
+
   ## Examples
 
       iex> System.put_env("HELLO", "world")
       iex> Envar.get("HELLO")
       "world"
 
+      iex> Envar.get("FOO", "bar")
+      "bar"
+
   """
-  @spec get(binary) :: binary | nil
-  def get(varname) do
-    case System.get_env(varname) do
-      nil ->
+  @spec get(binary, binary) :: binary | nil
+  def get(varname, default \\ nil) do
+    case {System.get_env(varname), default} do
+      {nil, nil} ->
         Logger.error("ERROR: #{varname} Environment Variable is not set")
         nil
-      val ->
+      {val, nil} ->
+        val
+      {nil, val} ->
         val
     end
   end
@@ -182,7 +190,7 @@ defmodule Envar do
       with line <- String.replace(line, ["export ", "'"], ""),
            [key | rest] <- String.split(line, "="),
            value <- Enum.join(rest, "=") do
-        
+
         if String.length(value) > 0 do
           Map.put(acc, key, value)
         else

--- a/test/envar_test.exs
+++ b/test/envar_test.exs
@@ -11,6 +11,10 @@ defmodule EnvarTest do
     assert Envar.get("UNSET") == nil
   end
 
+  test "Envar.get/1 FOO returns \"bar\"" do
+    assert Envar.get("FOO", "bar") == "bar"
+  end
+
   test "Envar.is_set? UNSET returns false" do
     assert Envar.is_set?("UNSET") == false
   end
@@ -63,7 +67,7 @@ defmodule EnvarTest do
   end
 
   test "Envar.values(\".env\") reads the .env file the list of values" do
-    assert Envar.values(".env") == 
+    assert Envar.values(".env") ==
       ["alex@gmail.com", "awesome!", "master plan"]
   end
 end


### PR DESCRIPTION
I'm not sure If you are accepting PRs - if not, feel free to close this PR. 

This PR adds optional parameter to Envar.get/1 , so It's possible to set default value if ENV variable is not set or specified.
I'm pretty new to Elixir, so I'm not sure if HexDocs is correct. 